### PR TITLE
Updates for Python 3 compatibility

### DIFF
--- a/dxleventreporting.py
+++ b/dxleventreporting.py
@@ -36,6 +36,7 @@ file under the "[dxleventreporting]" section in Cuckoo's report.conf file.
 For more information on the OpenDXL Python Client please see https://github.com/opendxl/opendxl-client-python/wiki.
 """
 
+from __future__ import absolute_import
 import calendar
 import datetime
 import json
@@ -51,6 +52,7 @@ from cuckoo.common.exceptions import CuckooReportError
 from dxlclient.client import DxlClient
 from dxlclient.client_config import DxlClientConfig
 from dxlclient.message import Event
+from functools import reduce
 
 # Logger
 log = logging.getLogger(__name__)

--- a/sample/basic/basic_subscribe_to_compressed_cuckoo_report.py
+++ b/sample/basic/basic_subscribe_to_compressed_cuckoo_report.py
@@ -3,6 +3,8 @@
 # waits to receive the compressed Cuckoo report analyses. In order for the OpenDXL Cuckoo Reporting Module
 # to broadcast the compressed Cuckoo report analyses, the "send_compressed_event" setting under the
 # "[dxleventreporting]" section of Cuckoo's reporting.conf file must be enabled.
+from __future__ import absolute_import
+from __future__ import print_function
 import json
 import logging
 import os
@@ -44,13 +46,13 @@ with DxlClient(config) as client:
             print("Cuckoo compressed report received: ")
 
             decompressed_event_dict = json.loads(decompressed_event_payload.decode(encoding="UTF-8"))
-            print json.dumps(decompressed_event_dict, sort_keys=True, indent=4, separators=(',', ': ')) + "\n"
+            print(json.dumps(decompressed_event_dict, sort_keys=True, indent=4, separators=(',', ': ')) + "\n")
 
     # Register the callback with the client
     client.add_event_callback(EVENT_TOPIC, CuckooCompressedReportEventCallback())
 
     # Wait until all events have been received
-    print "Waiting for Cuckoo compressed reports to be received..."
+    print("Waiting for Cuckoo compressed reports to be received...")
     while True:
         # Loop forever
         time.sleep(60)

--- a/sample/basic/basic_subscribe_to_cuckoo_report.py
+++ b/sample/basic/basic_subscribe_to_cuckoo_report.py
@@ -1,6 +1,8 @@
 # This sample demonstrates how to register a callback to receive Event messages
 # from the DXL fabric for the default Cuckoo report analysis. Once the callback is registered, the sample
 # waits to receive Cuckoo report analyses.
+from __future__ import absolute_import
+from __future__ import print_function
 import json
 import logging
 import os
@@ -38,13 +40,13 @@ with DxlClient(config) as client:
             print("Cuckoo report received: ")
 
             event_dict = json.loads(event.payload.decode(encoding="UTF-8"))
-            print json.dumps(event_dict, sort_keys=True, indent=4, separators=(',', ': ')) + "\n"
+            print(json.dumps(event_dict, sort_keys=True, indent=4, separators=(',', ': ')) + "\n")
 
     # Register the callback with the client
     client.add_event_callback(EVENT_TOPIC, CuckooReportEventCallback())
 
     # Wait until all events have been received
-    print "Waiting for Cuckoo reports to be received..."
+    print("Waiting for Cuckoo reports to be received...")
     while True:
         # Loop forever
         time.sleep(60)

--- a/sample/common.py
+++ b/sample/common.py
@@ -4,6 +4,7 @@ This includes the defining the path to the configuration file used to initialize
 in addition to setting up the logger appropriately.
 """
 
+from __future__ import absolute_import
 import os
 import logging
 


### PR DESCRIPTION
This PR contains a few updates to the reporting module and samples for Python 3 compatibility. Note that the Cuckoo Sandbox project itself [has not been updated to support Python 3](https://github.com/cuckoosandbox/cuckoo/issues/594) so the "dxleventreporting.py" changes are not particularly useful at this point. I did at least test to see that Python 2 compatibility is not broken by any of these changes.